### PR TITLE
Fixed article class naming issue

### DIFF
--- a/scripts/mexico/landmarks/Landmark.js
+++ b/scripts/mexico/landmarks/Landmark.js
@@ -1,7 +1,7 @@
 // Exports to LandmarkList.js
 export function MexicoLandmark(landmarkObject) {
     return `
-    <article class="celebrity-card">
+    <article class="landmark-card">
         <ul class="list-child">
             <li class="list-item">${landmarkObject.landmark}</li>
         </ul>


### PR DESCRIPTION
Fixed the article class in Mexico/Landmark.js from "celebrity-card" to "landmark-card"